### PR TITLE
Fix mobile docs landing page

### DIFF
--- a/apps/docs/components/LandingPage.module.css
+++ b/apps/docs/components/LandingPage.module.css
@@ -1,0 +1,273 @@
+.page {
+  width: 100vw;
+  min-height: 100vh;
+  margin-top: -4rem;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  overflow-x: hidden;
+  color: #e5eefc;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(71, 117, 255, 0.34), transparent 30rem),
+    radial-gradient(circle at 90% 6%, rgba(34, 211, 238, 0.22), transparent 26rem),
+    linear-gradient(135deg, #06111f 0%, #0a1324 45%, #0f172a 100%);
+}
+
+.container {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: clamp(4.75rem, 9vw, 6rem) clamp(1rem, 4vw, 2rem) 3rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.heroCopy {
+  min-width: 0;
+}
+
+.badge {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 0.5rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.62);
+  color: #b6c4db;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.eyebrow {
+  margin: 1.1rem 0 0.75rem;
+  color: #67e8f9;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.title {
+  max-width: 14ch;
+  margin: 0;
+  color: #f8fbff;
+  font-size: clamp(2.55rem, 13vw, 5.1rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+  text-wrap: balance;
+}
+
+.subtitle {
+  max-width: 38rem;
+  margin: 1.2rem 0 0;
+  color: #b7c6dc;
+  font-size: clamp(1rem, 4.4vw, 1.22rem);
+  line-height: 1.7;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-top: 1.75rem;
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 1.15rem;
+  border-radius: 14px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.primaryCta {
+  color: #ffffff;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  box-shadow: 0 16px 40px rgba(99, 102, 241, 0.35);
+}
+
+.secondaryCta {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.terminal {
+  min-width: 0;
+  max-width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 22px;
+  overflow: hidden;
+  background: rgba(2, 6, 23, 0.78);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+}
+
+.terminalBar {
+  display: flex;
+  gap: 8px;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+}
+
+.dotRed {
+  background: #fb7185;
+}
+
+.dotYellow {
+  background: #facc15;
+}
+
+.dotGreen {
+  background: #34d399;
+}
+
+.code {
+  max-width: 100%;
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  color: #dbeafe;
+  font-size: clamp(0.72rem, 2.85vw, 0.84rem);
+  line-height: 1.65;
+  -webkit-overflow-scrolling: touch;
+}
+
+.section {
+  margin-top: clamp(4rem, 10vw, 5.5rem);
+}
+
+.sectionTitle {
+  max-width: 780px;
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(2rem, 9vw, 3.1rem);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.sectionCopy {
+  max-width: 760px;
+  margin: 1rem 0 0;
+  color: #aebdd2;
+  font-size: 1.02rem;
+  line-height: 1.75;
+}
+
+.featureGrid,
+.comparisonGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  margin-top: 1.6rem;
+}
+
+.featureCard,
+.comparisonCard {
+  min-width: 0;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.featureCard {
+  padding: 1.15rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.76), rgba(15, 23, 42, 0.38));
+}
+
+.comparisonCard {
+  padding: 1.25rem;
+}
+
+.cardIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  color: #67e8f9;
+  font-weight: 900;
+  background: rgba(56, 189, 248, 0.13);
+}
+
+.cardTitle {
+  margin: 1rem 0 0.55rem;
+  color: #f8fafc;
+  font-size: 1.13rem;
+}
+
+.cardBody {
+  margin: 0;
+  color: #aebdd2;
+  line-height: 1.65;
+}
+
+.listTitle {
+  margin-top: 0;
+  color: #f8fafc;
+}
+
+.list {
+  margin-bottom: 0;
+  padding-left: 1.2rem;
+  color: #b7c6dc;
+  line-height: 1.9;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  color: #94a3b8;
+}
+
+@media (min-width: 520px) {
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+@media (min-width: 720px) {
+  .featureGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .comparisonGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .footer {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 980px) {
+  .hero {
+    grid-template-columns: minmax(0, 0.96fr) minmax(0, 1fr);
+    gap: 2.25rem;
+  }
+
+  .featureGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/apps/docs/components/LandingPage.tsx
+++ b/apps/docs/components/LandingPage.tsx
@@ -1,201 +1,5 @@
 import React from 'react'
-
-const shell: React.CSSProperties = {
-  minHeight: '100vh',
-  margin: '-4rem -2rem 0',
-  padding: '5rem 2rem 3rem',
-  color: '#e5eefc',
-  background:
-    'radial-gradient(circle at 15% 0%, rgba(71, 117, 255, 0.32), transparent 32rem), radial-gradient(circle at 85% 8%, rgba(34, 211, 238, 0.22), transparent 30rem), linear-gradient(135deg, #06111f 0%, #0a1324 45%, #0f172a 100%)',
-}
-
-const container: React.CSSProperties = {
-  width: 'min(1120px, 100%)',
-  margin: '0 auto',
-}
-
-const heroGrid: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'minmax(0, 0.96fr) minmax(360px, 1fr)',
-  gap: '2.25rem',
-  alignItems: 'center',
-}
-
-const badge: React.CSSProperties = {
-  display: 'inline-flex',
-  padding: '0.5rem 0.8rem',
-  border: '1px solid rgba(148, 163, 184, 0.28)',
-  borderRadius: 999,
-  background: 'rgba(15, 23, 42, 0.62)',
-  color: '#b6c4db',
-  fontSize: '0.86rem',
-}
-
-const eyebrow: React.CSSProperties = {
-  margin: '1.25rem 0 0.75rem',
-  color: '#67e8f9',
-  fontWeight: 700,
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  fontSize: '0.8rem',
-}
-
-const title: React.CSSProperties = {
-  maxWidth: 620,
-  margin: 0,
-  fontSize: 'clamp(3rem, 5.7vw, 5.25rem)',
-  lineHeight: 0.98,
-  letterSpacing: '-0.065em',
-  color: '#f8fbff',
-}
-
-const subtitle: React.CSSProperties = {
-  maxWidth: 560,
-  margin: '1.4rem 0 0',
-  color: '#b7c6dc',
-  fontSize: 'clamp(1.05rem, 2vw, 1.25rem)',
-  lineHeight: 1.75,
-}
-
-const actions: React.CSSProperties = {
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: '0.9rem',
-  marginTop: '2rem',
-}
-
-const primaryLink: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  minHeight: 48,
-  padding: '0 1.2rem',
-  borderRadius: 14,
-  background: 'linear-gradient(135deg, #38bdf8, #6366f1)',
-  color: '#ffffff',
-  fontWeight: 800,
-  textDecoration: 'none',
-  boxShadow: '0 16px 40px rgba(99, 102, 241, 0.35)',
-}
-
-const secondaryLink: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  minHeight: 48,
-  padding: '0 1.2rem',
-  borderRadius: 14,
-  border: '1px solid rgba(148, 163, 184, 0.35)',
-  background: 'rgba(15, 23, 42, 0.58)',
-  color: '#e2e8f0',
-  fontWeight: 750,
-  textDecoration: 'none',
-}
-
-const panel: React.CSSProperties = {
-  border: '1px solid rgba(148, 163, 184, 0.22)',
-  borderRadius: 28,
-  overflow: 'hidden',
-  background: 'rgba(2, 6, 23, 0.78)',
-  boxShadow: '0 30px 100px rgba(0, 0, 0, 0.38)',
-}
-
-const panelHeader: React.CSSProperties = {
-  display: 'flex',
-  gap: 8,
-  padding: '1rem',
-  borderBottom: '1px solid rgba(148, 163, 184, 0.16)',
-  background: 'rgba(15, 23, 42, 0.72)',
-}
-
-const dot = (color: string): React.CSSProperties => ({
-  width: 11,
-  height: 11,
-  borderRadius: 999,
-  background: color,
-})
-
-const codeBlock: React.CSSProperties = {
-  margin: 0,
-  padding: '1.3rem',
-  color: '#dbeafe',
-  fontSize: '0.82rem',
-  lineHeight: 1.7,
-  overflowX: 'auto',
-}
-
-const section: React.CSSProperties = {
-  marginTop: '5.5rem',
-}
-
-const sectionTitle: React.CSSProperties = {
-  margin: 0,
-  color: '#f8fafc',
-  fontSize: 'clamp(2rem, 4vw, 3.1rem)',
-  letterSpacing: '-0.055em',
-  lineHeight: 1,
-}
-
-const sectionCopy: React.CSSProperties = {
-  margin: '1rem 0 0',
-  maxWidth: 760,
-  color: '#aebdd2',
-  lineHeight: 1.75,
-  fontSize: '1.05rem',
-}
-
-const featureGrid: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-  gap: '1rem',
-  marginTop: '1.8rem',
-}
-
-const featureCard: React.CSSProperties = {
-  minHeight: 190,
-  padding: '1.25rem',
-  border: '1px solid rgba(148, 163, 184, 0.18)',
-  borderRadius: 24,
-  background:
-    'linear-gradient(180deg, rgba(15, 23, 42, 0.76), rgba(15, 23, 42, 0.38))',
-}
-
-const cardIcon: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: 38,
-  height: 38,
-  borderRadius: 12,
-  background: 'rgba(56, 189, 248, 0.13)',
-  color: '#67e8f9',
-  fontWeight: 900,
-}
-
-const comparisonGrid: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-  gap: '1rem',
-  marginTop: '1.8rem',
-}
-
-const comparisonCard: React.CSSProperties = {
-  padding: '1.4rem',
-  border: '1px solid rgba(148, 163, 184, 0.18)',
-  borderRadius: 24,
-  background: 'rgba(15, 23, 42, 0.55)',
-}
-
-const footer: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  gap: '1rem',
-  flexWrap: 'wrap',
-  marginTop: '5rem',
-  paddingTop: '2rem',
-  borderTop: '1px solid rgba(148, 163, 184, 0.18)',
-  color: '#94a3b8',
-}
+import styles from './LandingPage.module.css'
 
 const code = `const contract = defineContract({
   chat: {
@@ -253,80 +57,78 @@ const features = [
 
 export function LandingPage() {
   return (
-    <main style={shell}>
-      <div style={container}>
-        <section style={heroGrid}>
-          <div>
-            <span style={badge}>Type-safe realtime protocols for TypeScript</span>
-            <p style={eyebrow}>Contract-first actions and listeners</p>
-            <h1 style={title}>Build socket APIs without stringly typed events.</h1>
-            <p style={subtitle}>
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <span className={styles.badge}>Type-safe realtime protocols for TypeScript</span>
+            <p className={styles.eyebrow}>Contract-first actions and listeners</p>
+            <h1 className={styles.title}>Build socket APIs without stringly typed events.</h1>
+            <p className={styles.subtitle}>
               tsio lets you define a shared contract once and use it to type server handlers, client
               actions, client listeners, middleware context, and socket transport adapters.
             </p>
-            <div style={actions}>
-              <a href="/docs/getting-started" style={primaryLink}>
+            <div className={styles.actions}>
+              <a href="/docs/getting-started" className={styles.primaryCta}>
                 Get started
               </a>
-              <a href="/docs/introduction" style={secondaryLink}>
+              <a href="/docs/introduction" className={styles.secondaryCta}>
                 Read the docs
               </a>
-              <a href="https://github.com/xaviercariza/tsio" style={secondaryLink}>
+              <a href="https://github.com/xaviercariza/tsio" className={styles.secondaryCta}>
                 GitHub
               </a>
             </div>
           </div>
 
-          <div style={panel}>
-            <div style={panelHeader}>
-              <span style={dot('#fb7185')} />
-              <span style={dot('#facc15')} />
-              <span style={dot('#34d399')} />
+          <div className={styles.terminal}>
+            <div className={styles.terminalBar}>
+              <span className={`${styles.dot} ${styles.dotRed}`} />
+              <span className={`${styles.dot} ${styles.dotYellow}`} />
+              <span className={`${styles.dot} ${styles.dotGreen}`} />
             </div>
-            <pre style={codeBlock}>
+            <pre className={styles.code}>
               <code>{code}</code>
             </pre>
           </div>
         </section>
 
-        <section style={section}>
-          <h2 style={sectionTitle}>Built for bidirectional TypeScript apps.</h2>
-          <p style={sectionCopy}>
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Built for bidirectional TypeScript apps.</h2>
+          <p className={styles.sectionCopy}>
             Use tsio when the client calls server actions and the server emits typed listener events
             back to connected clients. The contract keeps both directions in sync.
           </p>
-          <div style={featureGrid}>
+          <div className={styles.featureGrid}>
             {features.map(feature => (
-              <article key={feature.title} style={featureCard}>
-                <span style={cardIcon}>{feature.icon}</span>
-                <h3 style={{ color: '#f8fafc', margin: '1rem 0 0.55rem', fontSize: '1.18rem' }}>
-                  {feature.title}
-                </h3>
-                <p style={{ color: '#aebdd2', lineHeight: 1.65, margin: 0 }}>{feature.body}</p>
+              <article key={feature.title} className={styles.featureCard}>
+                <span className={styles.cardIcon}>{feature.icon}</span>
+                <h3 className={styles.cardTitle}>{feature.title}</h3>
+                <p className={styles.cardBody}>{feature.body}</p>
               </article>
             ))}
           </div>
         </section>
 
-        <section style={section}>
-          <h2 style={sectionTitle}>Use it when your API has a pulse.</h2>
-          <p style={sectionCopy}>
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Use it when your API has a pulse.</h2>
+          <p className={styles.sectionCopy}>
             tsio is designed for live systems where connected clients need typed actions,
             acknowledgements, and server-pushed updates.
           </p>
-          <div style={comparisonGrid}>
-            <div style={comparisonCard}>
-              <h3 style={{ color: '#f8fafc', marginTop: 0 }}>Great fit</h3>
-              <ul style={{ color: '#b7c6dc', lineHeight: 1.9, paddingLeft: '1.2rem' }}>
+          <div className={styles.comparisonGrid}>
+            <div className={styles.comparisonCard}>
+              <h3 className={styles.listTitle}>Great fit</h3>
+              <ul className={styles.list}>
                 <li>Realtime chat and presence</li>
                 <li>Game rooms and multiplayer sessions</li>
                 <li>Collaborative document updates</li>
                 <li>Live dashboards and admin consoles</li>
               </ul>
             </div>
-            <div style={comparisonCard}>
-              <h3 style={{ color: '#f8fafc', marginTop: 0 }}>Not the first choice</h3>
-              <ul style={{ color: '#b7c6dc', lineHeight: 1.9, paddingLeft: '1.2rem' }}>
+            <div className={styles.comparisonCard}>
+              <h3 className={styles.listTitle}>Not the first choice</h3>
+              <ul className={styles.list}>
                 <li>Plain CRUD APIs that only need HTTP</li>
                 <li>Static content delivery</li>
                 <li>One-off form submissions without live updates</li>
@@ -336,7 +138,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <footer style={footer}>
+        <footer className={styles.footer}>
           <span>Contract-first realtime for TypeScript.</span>
           <span>MIT · Socket.IO · ws · Zod</span>
         </footer>


### PR DESCRIPTION
## Summary

Fixes the docs landing page on mobile by replacing the desktop-only inline layout with a responsive CSS module implementation.

## Changes

- Replace inline style objects in `LandingPage.tsx` with class names.
- Add `LandingPage.module.css` with mobile-first breakpoints.
- Stack the hero and code panel on small screens.
- Make CTA buttons full-width on mobile.
- Use single-column cards on mobile, then expand to multi-column layouts on larger screens.
- Reduce horizontal overflow risk from the full-width Nextra landing layout.

## Testing

Not run locally in this environment. The Vercel preview for this PR should be used to verify the mobile layout.
