### PR TITLE
[codex] Fix playground start resolution

### DIFF
--- a/apps/playground/src/server/store/index.ts
+++ b/apps/playground/src/server/store/index.ts
@@ -217,6 +217,7 @@ export {
   getAllUsers,
   getGroup,
   getGroupsForUser,
+  getUserById,
   getUserByNickname,
   getUserSocketId,
   getUserWithPasswordByNickname,

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -18,6 +18,12 @@
       "types": "./dist/server.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      "client": ["dist/client.d.ts"],
+      "server": ["dist/server.d.ts"]
+    }
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION
## Summary

- Add `typesVersions` entries for `@tsio/socketio/client` and `@tsio/socketio/server` so legacy TypeScript resolution used by the playground's `ts-node` start script can find the built declaration files.
- Export `getUserById` from the playground in-memory store, matching existing imports in the playground services and router.

## Root cause

The playground runs through `ts-node` with legacy `moduleResolution: node`, which does not resolve package `exports` subpaths for type lookup. After that was fixed, startup reached an existing compile error because `getUserById` was declared but not exported from the store module.

## Validation

- `pnpm --filter @tsio/playground exec tsc --noEmit --pretty false`
- `pnpm --filter @tsio/socketio exec tsc --noEmit --pretty false`