### PR TITLE
[codex] Prepare 0.1.0 minor release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }

--- a/.changeset/minor-modern-runtime.md
+++ b/.changeset/minor-modern-runtime.md
@@ -1,0 +1,7 @@
+---
+"@tsio/core": minor
+"@tsio/socketio": minor
+"@tsio/ws": minor
+---
+
+Modernize the runtime and dependency baseline, refresh adapter peer ranges, and keep the public library surface compatible with both Zod 3 and Zod 4 consumers.

--- a/.changeset/minor-modern-runtime.md
+++ b/.changeset/minor-modern-runtime.md
@@ -4,4 +4,44 @@
 "@tsio/ws": minor
 ---
 
-Modernize the runtime and dependency baseline, refresh adapter peer ranges, and keep the public library surface compatible with both Zod 3 and Zod 4 consumers.
+Release the accumulated library work since `@tsio/*@0.0.3`.
+
+This is a minor release for the pre-1.0 packages. It includes public API cleanup, type-system fixes, adapter fixes, documentation updates, playground simplification, and the dependency/security modernization work.
+
+### Core API and types
+
+- Refactored the core contract, action, router, client, middleware, emitter, and adapter types around a smaller contract-first API surface.
+- Preserved compatibility exports where possible while moving the legacy implementation out of the active typecheck path.
+- Improved typed client generation, router/action builders, middleware context refinement, and response inference.
+- Exposed action paths to resolvers and handlers.
+- Exported response helper types for application and adapter type tests.
+- Fixed declaration build issues around piped middleware arrays.
+- Added broader runtime and type-level coverage for routers, validation, clients, emitters, and middleware context refinement.
+
+### Zod compatibility
+
+- Updated `@tsio/core` to support both Zod 3 and Zod 4 consumers through the peer range `^3.22.4 || ^4.0.0`.
+- Switched the repository dev/test dependency to Zod 4 and added type tests proving the public surface remains structurally compatible.
+
+### Socket.IO and WS adapters
+
+- Updated Socket.IO and WS peer ranges to current compatible major lines.
+- Fixed Socket.IO `emitTo` so it targets the requested socket id.
+- Fixed the WS client adapter to use listener dot paths consistently.
+- Replaced `uuid` usage with `node:crypto.randomUUID()` so the packages keep CJS output without depending on the latest ESM-only UUID package.
+
+### Packaging and runtime baseline
+
+- Preserved CJS and ESM package outputs for the core, Socket.IO, and WS packages.
+- Added explicit `exports` metadata for `@tsio/core`.
+- Cleaned npm package contents so published tarballs include only `dist`, changelogs, license, and package metadata.
+- Moved repository development to Node 24 and pnpm 11.
+- Modernized direct tooling and framework dependencies, including Turbo 2, Biome 2, TypeScript 6, Vitest 4, React 19, Next 16, Nextra 4, Tailwind 4, Express 5, and bcrypt 6.
+- Updated CI to the new Node/pnpm baseline and fixed clean-checkout typecheck ordering so dependency package declarations are built before dependent packages run `tsc`.
+
+### Docs and playground
+
+- Replaced the placeholder docs with production documentation for introduction, getting started, contracts, routers, clients, middleware, validation, transports, testing, guides, and API reference pages.
+- Migrated the docs app to Nextra 4 App Router structure and Tailwind 4.
+- Removed old placeholder docs routes for About, Core/Contract, and Core/Server.
+- Reworked the playground around an in-memory store, removed stale Prisma files, simplified the demo UI, and migrated the playground Vite/Tailwind setup.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "Xavier Cardona",
   "version": "0.0.3",
+  "files": [
+    "CHANGELOG.md",
+    "dist"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "Xavier Cardona",
   "version": "0.0.3",
+  "files": [
+    "CHANGELOG.md",
+    "dist"
+  ],
   "exports": {
     "./package.json": "./package.json",
     "./client": {
@@ -44,7 +48,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@tsio/core": "workspace:^",
+    "@tsio/core": "^0.0.3 || ^0.1.0",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"
   }

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "Xavier Cardona",
   "version": "0.0.3",
+  "files": [
+    "CHANGELOG.md",
+    "dist"
+  ],
   "exports": {
     "./client": {
       "types": "./dist/client.d.ts",
@@ -33,7 +37,7 @@
     "ws": "^8.21.0"
   },
   "peerDependencies": {
-    "@tsio/core": "workspace:^",
+    "@tsio/core": "^0.0.3 || ^0.1.0",
     "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary

Prepare the next npm release for the public tsio packages after the dependency modernization and public API refactor.

## What Changed

- Adds a Changeset marking the public packages for a minor release:
  - `@tsio/core`: `0.0.3` -> `0.1.0`
  - `@tsio/socketio`: `0.0.3` -> `0.1.0`
  - `@tsio/ws`: `0.0.3` -> `0.1.0`
- Keeps private workspace packages out of the release plan.
- Enables Changesets peer-dependent handling so the adapter packages are not escalated to `1.0.0` just because `@tsio/core` moves from `0.0.x` to `0.1.x`.
- Narrows the adapter peer range for `@tsio/core` to the compatible pre-1.0 lines: `^0.0.3 || ^0.1.0`.
- Adds `files` whitelists to the three published packages so npm tarballs include only built output, changelogs, license, and package metadata instead of `.turbo` logs/source/config files.

## Why

The dependency modernization PR refactored the public API and compatibility surface enough that a patch release would understate the change. Since the packages are still `0.x`, a minor release to `0.1.0` is the appropriate signal without declaring the library stable as `1.0.0`.

## Validation

Ran on a branch created from updated `origin/main`:

- `pnpm install --frozen-lockfile`
- `pnpm changeset status --since origin/main`
  - computed `0.1.0` for `@tsio/core`, `@tsio/socketio`, and `@tsio/ws`
- `pnpm lint`
- `pnpm types-check`
- `pnpm --filter @tsio/core pack --dry-run`
- `pnpm --filter @tsio/socketio pack --dry-run`
- `pnpm --filter @tsio/ws pack --dry-run`

The pack dry-runs show clean package contents: `dist`, `CHANGELOG.md`, `LICENSE`, and `package.json`.